### PR TITLE
Add A and B field decoding for LD

### DIFF
--- a/include/inst_ld.h
+++ b/include/inst_ld.h
@@ -5,6 +5,5 @@
 #include "mem.h"
 
 int isa_ld(Cpub *cpub, const Instruction *inst);
-void ld_write_acc(Cpub *cpub, Uword val);
 
 #endif /* INST_LD_H */

--- a/include/isa.h
+++ b/include/isa.h
@@ -8,20 +8,27 @@ typedef enum {
 } Opcode;
 
 typedef enum {
-    AM_ACC = 0x00,
-    AM_IX = 0x01,
-    AM_IMM = 0x02,
-    AM_ABS = 0x04,
-    AM_ABS_D = 0x05,
-    AM_IX_D = 0x06,
-    AM_IX_DD = 0x07,
-} AddressingMode;
+    DEST_ACC = 0,
+    DEST_IX  = 1,
+} DestReg;
+
+typedef enum {
+    OP_B_ACC   = 0x0,
+    OP_B_IX    = 0x1,
+    OP_B_IMM   = 0x2, /* 010 or 011 */
+    OP_B_ABS_P = 0x4,
+    OP_B_ABS_D = 0x5,
+    OP_B_IX_P  = 0x6,
+    OP_B_IX_D  = 0x7,
+} OperandMode;
 
 typedef struct {
-    Uword raw;
-    Opcode opcode;
-    AddressingMode addressing_mode;
-    Uword imm;
+    Uword raw;      /* first byte */
+    Opcode opcode;  /* high nibble */
+    DestReg dest;   /* A bit */
+    OperandMode mode; /* B field */
+    Uword d;        /* B' byte if present */
+    Uword imm;      /* decoded operand */
 } Instruction;
 
 typedef int (*ExecFunc)(Cpub *, const Instruction *);

--- a/src/cpu_decode.c
+++ b/src/cpu_decode.c
@@ -1,30 +1,40 @@
 #include "cpu_decode.h"
 
-void decode(Cpub *cpub, Instruction *inst) {
-    switch (inst->addressing_mode) {
-        case AM_ACC:
-            inst->imm = cpub->acc;
-            break;
-        case AM_IX:
-            inst->imm = cpub->ix;
-            break;
-        case AM_IMM:
-            // Immediate value is already set in inst->imm
-            break;
-        case AM_ABS:
-            inst->imm = mem_read(cpub, inst->raw & 0xFF);
-            break;
-        case AM_ABS_D:
-            inst->imm = mem_read(cpub, (inst->raw & 0xFF) + cpub->pc);
-            break;
-        case AM_IX_D:
-            inst->imm = mem_read(cpub, (inst->raw & 0xFF) + cpub->ix);
-            break;
-        case AM_IX_DD:
-            inst->imm = mem_read(cpub, (inst->raw & 0xFF) + cpub->ix + cpub->pc);
-            break;
-        default:
-            // Handle unknown addressing mode
-            inst->imm = 0; // Default to zero if unknown
+static int needs_operand(OperandMode mode)
+{
+    return !(mode == OP_B_ACC || mode == OP_B_IX);
+}
+
+void decode(Cpub *cpub, Instruction *inst)
+{
+    if (needs_operand(inst->mode)) {
+        inst->d = mem_read(cpub, cpub->pc++);
+    }
+
+    switch (inst->mode) {
+    case OP_B_ACC:
+        inst->imm = cpub->acc;
+        break;
+    case OP_B_IX:
+        inst->imm = cpub->ix;
+        break;
+    case OP_B_IMM:
+        inst->imm = inst->d;
+        break;
+    case OP_B_ABS_P:
+        inst->imm = mem_read(cpub, inst->d & 0xFF);
+        break;
+    case OP_B_ABS_D:
+        inst->imm = mem_read(cpub, 0x100 | (inst->d & 0xFF));
+        break;
+    case OP_B_IX_P:
+        inst->imm = mem_read(cpub, (cpub->ix + inst->d) & 0xFF);
+        break;
+    case OP_B_IX_D:
+        inst->imm = mem_read(cpub, 0x100 | ((cpub->ix + inst->d) & 0xFF));
+        break;
+    default:
+        inst->imm = 0;
+        break;
     }
 }

--- a/src/cpu_fetch.c
+++ b/src/cpu_fetch.c
@@ -2,8 +2,14 @@
 
 int fetch(Cpub *cpub, Instruction *out)
 {
-    out->raw = mem_read(cpub, cpub->pc);
+    out->raw = mem_read(cpub, cpub->pc++);
     out->opcode = (Opcode)(out->raw & 0xF0);
-    out->addressing_mode = (AddressingMode)(out->raw & 0x0F);
+    out->dest = (DestReg)((out->raw >> 3) & 0x1);
+    Uword b = out->raw & 0x07;
+    if (b == 0x03)
+        b = 0x02; /* 010 and 011 are both immediate */
+    out->mode = (OperandMode)b;
+    out->d = 0;
+    out->imm = 0;
     return 1;
 }

--- a/src/inst_ld.c
+++ b/src/inst_ld.c
@@ -1,39 +1,18 @@
 #include "inst_ld.h"
 
-void ld_write_acc(Cpub *cpub, Uword val) {
-    cpub->acc = val;
+static void ld_write_reg(Cpub *cpub, DestReg dest, Uword val)
+{
+    if (dest == DEST_ACC) {
+        cpub->acc = val;
+    } else {
+        cpub->ix = val;
+    }
     cpub->zf = (val == 0);
     cpub->nf = (val & 0x80) != 0;
 }
 
 int isa_ld(Cpub *cpub, const Instruction *inst)
 {
-    Uword val = 0;
-    switch (inst->addressing_mode) {
-        case AM_ACC:
-            val = cpub->acc;
-            break;
-        case AM_IX:
-            val = cpub->ix;
-            break;
-        case AM_IMM:
-            val = inst->imm;
-            break;
-        case AM_ABS:
-            val = mem_read(cpub, inst->imm);
-            break;
-        case AM_ABS_D:
-            val = mem_read(cpub, (inst->imm + cpub->pc) & 0xFF);
-            break;
-        case AM_IX_D:
-            val = mem_read(cpub, (inst->imm + cpub->ix) & 0xFF);
-            break;
-        case AM_IX_DD:
-            val = mem_read(cpub, (inst->imm + cpub->ix + cpub->pc) & 0xFF);
-            break;
-        default:
-            return RUN_HALT;
-    }
-    ld_write_acc(cpub, val);
+    ld_write_reg(cpub, inst->dest, inst->imm);
     return RUN_STEP;
 }

--- a/tests/test_ld.sh
+++ b/tests/test_ld.sh
@@ -5,7 +5,7 @@ BIN="$SCRIPT_DIR/../cpu_project_2"
 
 output=$("$BIN" <<'EOS' 2>&1
 w 0 0x24
-w 0x24 0x60
+w 1 0x60
 w 0x60 0x55
 s pc 0
 s acc 0


### PR DESCRIPTION
## Summary
- implement A-bit destination and B-field addressing for the LD instruction
- fetch now decodes A and B bits and increments PC
- decode loads the B' byte when needed and resolves operand addresses
- LD writes to ACC or IX depending on the A bit
- update LD unit test for new instruction format

## Testing
- `make test`
- `sh tests/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_684cfd889fcc8333a153fdd727fd6311