### PR TITLE
Fix opcode comments for LD IX tests

### DIFF
--- a/tests/test_ld.sh
+++ b/tests/test_ld.sh
@@ -127,7 +127,7 @@ d
 q
 " "acc=0xbb"
 
-# 7. レジスタ指定: LD IX, IX (Opcode: 0x68)
+# 7. レジスタ指定: LD IX, IX (Opcode: 0x69)
 run_test "LD IX, IX" "
 w 0 0x69
 s pc 0
@@ -138,7 +138,7 @@ d
 q
 " "ix=0xb0.*nf=1"
 
-# 8. レジスタ指定: LD IX, ACC (Opcode: 0x69)
+# 8. レジスタ指定: LD IX, ACC (Opcode: 0x68)
 run_test "LD IX, ACC" "
 w 0 0x68
 s pc 0


### PR DESCRIPTION
## Summary
- correct opcode comment in LD IX, IX test
- correct opcode comment in LD IX, ACC test

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d258d89e88333a8687ca35a602f11