### PR TITLE
Implement ADC and SBC instructions

### DIFF
--- a/include/inst_adc.h
+++ b/include/inst_adc.h
@@ -1,0 +1,8 @@
+#ifndef INST_ADC_H
+#define INST_ADC_H
+
+#include "isa.h"
+
+int isa_adc(Cpub *cpub, const Instruction *inst);
+
+#endif /* INST_ADC_H */

--- a/include/inst_sbc.h
+++ b/include/inst_sbc.h
@@ -1,0 +1,8 @@
+#ifndef INST_SBC_H
+#define INST_SBC_H
+
+#include "isa.h"
+
+int isa_sbc(Cpub *cpub, const Instruction *inst);
+
+#endif /* INST_SBC_H */

--- a/include/isa.h
+++ b/include/isa.h
@@ -10,6 +10,8 @@ typedef enum {
     OP_B   = 0x30,
     OP_LD  = 0x60,
     OP_ST  = 0x70,
+    OP_SBC = 0x80,
+    OP_ADC = 0x90,
     OP_SUB = 0xA0,
     OP_ADD = 0xB0,
     OP_EOR = 0xC0,

--- a/src/inst_adc.c
+++ b/src/inst_adc.c
@@ -1,0 +1,33 @@
+#include "inst_adc.h"
+
+static Uword adc_read_reg(const Cpub *cpub, DestReg reg)
+{
+    return (reg == DEST_ACC) ? cpub->acc : cpub->ix;
+}
+
+static void adc_write_reg(Cpub *cpub, DestReg reg, Uword val)
+{
+    if (reg == DEST_ACC) {
+        cpub->acc = val;
+    } else {
+        cpub->ix = val;
+    }
+}
+
+int isa_adc(Cpub *cpub, const Instruction *inst)
+{
+    Uword src = adc_read_reg(cpub, inst->dest);
+    unsigned int operand = inst->imm + cpub->cf;
+    unsigned int sum = src + operand;
+    Uword result = sum & 0xFF;
+
+    adc_write_reg(cpub, inst->dest, result);
+
+    cpub->cf = (sum & 0x100) != 0;
+    Uword op8 = operand & 0xFF;
+    cpub->vf = (((src ^ result) & (op8 ^ result) & 0x80) != 0);
+    cpub->nf = (result & 0x80) != 0;
+    cpub->zf = (result == 0);
+
+    return RUN_STEP;
+}

--- a/src/inst_sbc.c
+++ b/src/inst_sbc.c
@@ -1,0 +1,33 @@
+#include "inst_sbc.h"
+
+static Uword sbc_read_reg(const Cpub *cpub, DestReg reg)
+{
+    return (reg == DEST_ACC) ? cpub->acc : cpub->ix;
+}
+
+static void sbc_write_reg(Cpub *cpub, DestReg reg, Uword val)
+{
+    if (reg == DEST_ACC) {
+        cpub->acc = val;
+    } else {
+        cpub->ix = val;
+    }
+}
+
+int isa_sbc(Cpub *cpub, const Instruction *inst)
+{
+    Uword src = sbc_read_reg(cpub, inst->dest);
+    unsigned int operand = inst->imm + cpub->cf;
+    unsigned int diff = src - operand;
+    Uword result = diff & 0xFF;
+
+    sbc_write_reg(cpub, inst->dest, result);
+
+    cpub->cf = (diff & 0x100) != 0;
+    Uword op8 = operand & 0xFF;
+    cpub->vf = (((src ^ op8) & (src ^ result) & 0x80) != 0);
+    cpub->nf = (result & 0x80) != 0;
+    cpub->zf = (result == 0);
+
+    return RUN_STEP;
+}

--- a/src/isa_table.c
+++ b/src/isa_table.c
@@ -3,7 +3,9 @@
 #include "inst_st.h"
 #include "inst_eor.h"
 #include "inst_add.h"
+#include "inst_adc.h"
 #include "inst_sub.h"
+#include "inst_sbc.h"
 #include "inst_bnz.h"
 #include "inst_hlt.h"
 #include "inst_io.h"
@@ -16,6 +18,8 @@ ExecFunc isa_exec_table[256] = {
     [OP_B]   = isa_bnz,
     [OP_LD]  = isa_ld,
     [OP_ST]  = isa_st,
+    [OP_SBC] = isa_sbc,
+    [OP_ADC] = isa_adc,
     [OP_SUB] = isa_sub,
     [OP_ADD] = isa_add,
     [OP_EOR] = isa_eor,

--- a/tests/test_adc.sh
+++ b/tests/test_adc.sh
@@ -1,0 +1,291 @@
+#!/bin/sh
+set -e
+SCRIPT_DIR="$(dirname "$0")"
+BIN="$SCRIPT_DIR/../cpu_project_2"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+TEST_COUNT=0
+
+run_test() {
+  TEST_NAME=$1
+  COMMANDS=$2
+  EXPECTED=$3
+
+  TEST_COUNT=$((TEST_COUNT + 1))
+  echo "--- Running test: $TEST_NAME ---"
+
+  output=$("$BIN" <<EOS 2>&1
+${COMMANDS}
+EOS
+)
+
+  if echo "$output" | grep -q "$EXPECTED"; then
+    echo "PASS"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL"
+    echo "====DEBUG INFO====="
+    echo "$output"
+    echo "==================="
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+  echo
+}
+
+# --- ADC命令のテストケース ---
+# 0. レジスタ指定: ADC ACC, ACC (Opcode: 0x90)
+run_test "ADC ACC, ACC" "
+w 0 0x90
+s pc 0
+s acc 0x01
+s cf 1
+i
+d
+q
+" "acc=0x03.*cf=0"
+
+# 1. レジスタ指定: ADC ACC, IX (Opcode: 0x91)
+run_test "ADC ACC, IX" "
+w 0 0x91
+s pc 0
+s acc 0x01
+s ix 0x01
+s cf 1
+i
+d
+q
+" "acc=0x03"
+
+# 2. 即値: ADC ACC, d (Opcode: 0x92)
+run_test "ADC ACC, d" "
+w 0 0x92
+w 1 0x05
+s pc 0
+s acc 0x03
+s cf 1
+i
+d
+q
+" "acc=0x09"
+
+# 3. 絶対アドレス（プログラム領域）: ADC ACC, [d] (Opcode: 0x94)
+run_test "ADC ACC, [d]" "
+w 0 0x94
+w 1 0x20
+w 0x20 0x07
+s pc 0
+s acc 0x01
+s cf 1
+i
+d
+q
+" "acc=0x09"
+
+# 4. 絶対アドレス（データ領域）: ADC ACC, (d) (Opcode: 0x95)
+run_test "ADC ACC, (d)" "
+w 0 0x95
+w 1 0x88
+w 0x188 0x04
+s pc 0
+s acc 0x01
+s cf 1
+i
+d
+q
+" "acc=0x06"
+
+# 5. IX修飾（プログラム領域）: ADC ACC, [IX+d] (Opcode: 0x96)
+run_test "ADC ACC, [IX+d]" "
+w 0 0x96
+w 1 0x10
+w 0x90 0x03
+s pc 0
+s acc 0x02
+s ix 0x80
+s cf 1
+i
+d
+q
+" "acc=0x06"
+
+# 6. IX修飾（データ領域）: ADC ACC, (IX+d) (Opcode: 0x97)
+run_test "ADC ACC, (IX+d)" "
+w 0 0x97
+w 1 0x10
+w 0x190 0x06
+s pc 0
+s acc 0x02
+s ix 0x80
+s cf 1
+i
+d
+q
+" "acc=0x09"
+
+# 7. レジスタ指定: ADC IX, ACC (Opcode: 0x98)
+run_test "ADC IX, ACC" "
+w 0 0x98
+s pc 0
+s ix 0x01
+s acc 0x02
+s cf 1
+i
+d
+q
+" "ix=0x04"
+
+# 8. レジスタ指定: ADC IX, IX (Opcode: 0x99)
+run_test "ADC IX, IX" "
+w 0 0x99
+s pc 0
+s ix 0x01
+s cf 1
+i
+d
+q
+" "ix=0x03"
+
+# 9. 即値: ADC IX, d (Opcode: 0x9A)
+run_test "ADC IX, d" "
+w 0 0x9a
+w 1 0x01
+s pc 0
+s ix 0x01
+s cf 1
+i
+d
+q
+" "ix=0x03"
+
+# 10. 絶対アドレス（プログラム領域）: ADC IX, [d] (Opcode: 0x9C)
+run_test "ADC IX, [d]" "
+w 0 0x9c
+w 1 0x30
+w 0x30 0x01
+s pc 0
+s ix 0x01
+s cf 1
+i
+d
+q
+" "ix=0x03"
+
+# 11. 絶対アドレス（データ領域）: ADC IX, (d) (Opcode: 0x9D)
+run_test "ADC IX, (d)" "
+w 0 0x9d
+w 1 0x90
+w 0x190 0x01
+s pc 0
+s ix 0x01
+s cf 1
+i
+d
+q
+" "ix=0x03"
+
+# 12. IX修飾（プログラム領域）: ADC IX, [IX+d] (Opcode: 0x9E)
+run_test "ADC IX, [IX+d]" "
+w 0 0x9e
+w 1 0x10
+w 0x90 0x01
+s pc 0
+s ix 0x80
+s cf 1
+i
+d
+q
+" "ix=0x82"
+
+# 13. IX修飾（データ領域）: ADC IX, (IX+d) (Opcode: 0x9F)
+run_test "ADC IX, (IX+d)" "
+w 0 0x9f
+w 1 0x10
+w 0x190 0x01
+s pc 0
+s ix 0x80
+s cf 1
+i
+d
+q
+" "ix=0x82"
+
+# 14. Carry発生確認
+run_test "ADC carry" "
+w 0 0x92
+w 1 0xff
+s pc 0
+s acc 0xff
+s cf 1
+i
+d
+q
+" "acc=0xff.*cf=1"
+
+# 15. VFセット例
+run_test "ADC VF" "
+w 0 0x92
+w 1 0x01
+s pc 0
+s acc 0x7f
+s cf 0
+i
+d
+q
+" "acc=0x80.*vf=1"
+
+# 16. CF=0 なら ADD と同じ動作
+run_test "ADC CF=0" "
+w 0 0x92
+w 1 0x02
+s pc 0
+s acc 0x01
+s cf 0
+i
+d
+q
+" "acc=0x03.*cf=0.*vf=0.*nf=0.*zf=0"
+
+# 17. ZF=1 になる例
+run_test "ADC ZF" "
+w 0 0x92
+w 1 0x00
+s pc 0
+s acc 0xff
+s cf 1
+i
+d
+q
+" "acc=0x00.*cf=1.*vf=0.*nf=0.*zf=1"
+
+# 18. 1語命令でPCが+1
+run_test "PC inc (1-byte) ADC ACC, ACC" "
+w 0 0x90
+s pc 0
+s cf 0
+i
+q
+" "CPU0,PC=0x1>"
+
+# 19. 2語命令でPCが+2
+run_test "PC inc (2-byte) ADC ACC, d" "
+w 0 0x92
+w 1 0x00
+s pc 0
+s cf 0
+i
+q
+" "CPU0,PC=0x2>"
+
+# --- テストサマリ ---
+echo "===================="
+echo "Test Summary"
+echo "===================="
+echo "TOTAL: $TEST_COUNT, PASS: $PASS_COUNT, FAIL: $FAIL_COUNT"
+echo
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  exit 1
+fi
+
+exit 0

--- a/tests/test_sbc.sh
+++ b/tests/test_sbc.sh
@@ -1,0 +1,279 @@
+#!/bin/sh
+set -e
+SCRIPT_DIR="$(dirname "$0")"
+BIN="$SCRIPT_DIR/../cpu_project_2"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+TEST_COUNT=0
+
+run_test() {
+  TEST_NAME=$1
+  COMMANDS=$2
+  EXPECTED=$3
+
+  TEST_COUNT=$((TEST_COUNT + 1))
+  echo "--- Running test: $TEST_NAME ---"
+
+  output=$("$BIN" <<EOS 2>&1
+${COMMANDS}
+EOS
+)
+
+  if echo "$output" | grep -q "$EXPECTED"; then
+    echo "PASS"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL"
+    echo "====DEBUG INFO====="
+    echo "$output"
+    echo "==================="
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+  echo
+}
+
+# --- SBC命令のテストケース ---
+# 0. レジスタ指定: SBC ACC, ACC (Opcode: 0x80)
+run_test "SBC ACC, ACC" "
+w 0 0x80
+s pc 0
+s acc 0x03
+s cf 1
+i
+d
+q
+" "acc=0xff.*cf=1"
+
+# 1. レジスタ指定: SBC ACC, IX (Opcode: 0x81)
+run_test "SBC ACC, IX" "
+w 0 0x81
+s pc 0
+s acc 0x05
+s ix 0x02
+s cf 1
+i
+d
+q
+" "acc=0x02"
+
+# 2. 即値: SBC ACC, d (Opcode: 0x82)
+run_test "SBC ACC, d" "
+w 0 0x82
+w 1 0x01
+s pc 0
+s acc 0x05
+s cf 1
+i
+d
+q
+" "acc=0x03"
+
+# 3. 絶対アドレス（プログラム領域）: SBC ACC, [d] (Opcode: 0x84)
+run_test "SBC ACC, [d]" "
+w 0 0x84
+w 1 0x20
+w 0x20 0x03
+s pc 0
+s acc 0x05
+s cf 1
+i
+d
+q
+" "acc=0x01"
+
+# 4. 絶対アドレス（データ領域）: SBC ACC, (d) (Opcode: 0x85)
+run_test "SBC ACC, (d)" "
+w 0 0x85
+w 1 0x88
+w 0x188 0x01
+s pc 0
+s acc 0x03
+s cf 1
+i
+d
+q
+" "acc=0x01"
+
+# 5. IX修飾（プログラム領域）: SBC ACC, [IX+d] (Opcode: 0x86)
+run_test "SBC ACC, [IX+d]" "
+w 0 0x86
+w 1 0x10
+w 0x90 0x02
+s pc 0
+s acc 0x05
+s ix 0x80
+s cf 1
+i
+d
+q
+" "acc=0x02"
+
+# 6. IX修飾（データ領域）: SBC ACC, (IX+d) (Opcode: 0x87)
+run_test "SBC ACC, (IX+d)" "
+w 0 0x87
+w 1 0x10
+w 0x190 0x01
+s pc 0
+s acc 0x05
+s ix 0x80
+s cf 1
+i
+d
+q
+" "acc=0x03"
+
+# 7. レジスタ指定: SBC IX, ACC (Opcode: 0x88)
+run_test "SBC IX, ACC" "
+w 0 0x88
+s pc 0
+s ix 0x05
+s acc 0x02
+s cf 1
+i
+d
+q
+" "ix=0x02"
+
+# 8. レジスタ指定: SBC IX, IX (Opcode: 0x89)
+run_test "SBC IX, IX" "
+w 0 0x89
+s pc 0
+s ix 0x05
+s cf 1
+i
+d
+q
+" "ix=0xff.*cf=1"
+
+# 9. 即値: SBC IX, d (Opcode: 0x8A)
+run_test "SBC IX, d" "
+w 0 0x8a
+w 1 0x01
+s pc 0
+s ix 0x05
+s cf 1
+i
+d
+q
+" "ix=0x03"
+
+# 10. 絶対アドレス（プログラム領域）: SBC IX, [d] (Opcode: 0x8C)
+run_test "SBC IX, [d]" "
+w 0 0x8c
+w 1 0x30
+w 0x30 0x03
+s pc 0
+s ix 0x05
+s cf 1
+i
+d
+q
+" "ix=0x01"
+
+# 11. 絶対アドレス（データ領域）: SBC IX, (d) (Opcode: 0x8D)
+run_test "SBC IX, (d)" "
+w 0 0x8d
+w 1 0x90
+w 0x190 0x02
+s pc 0
+s ix 0x05
+s cf 1
+i
+d
+q
+" "ix=0x02"
+
+# 12. IX修飾（プログラム領域）: SBC IX, [IX+d] (Opcode: 0x8E)
+run_test "SBC IX, [IX+d]" "
+w 0 0x8e
+w 1 0x10
+w 0x90 0x01
+s pc 0
+s ix 0x80
+s cf 1
+i
+d
+q
+" "ix=0x7e"
+
+# 13. IX修飾（データ領域）: SBC IX, (IX+d) (Opcode: 0x8F)
+run_test "SBC IX, (IX+d)" "
+w 0 0x8f
+w 1 0x10
+w 0x190 0x02
+s pc 0
+s ix 0x80
+s cf 1
+i
+d
+q
+" "ix=0x7d"
+
+# 14. BorrowでCFセット
+run_test "SBC borrow" "
+w 0 0x82
+w 1 0x02
+s pc 0
+s acc 0x01
+s cf 0
+i
+d
+q
+" "acc=0xff.*cf=1"
+
+# 15. VFセット例
+run_test "SBC VF" "
+w 0 0x82
+w 1 0x80
+s pc 0
+s acc 0x7f
+s cf 0
+i
+d
+q
+" "acc=0xff.*vf=1"
+
+# 16. 結果が0になるとZFが1
+run_test "SBC ZF" "
+w 0 0x82
+w 1 0x01
+s pc 0
+s acc 0x01
+s cf 0
+i
+d
+q
+" "acc=0x00.*cf=0.*vf=0.*nf=0.*zf=1"
+
+# 17. 1語命令でPCが+1
+run_test "PC inc (1-byte) SBC ACC, ACC" "
+w 0 0x80
+s pc 0
+s cf 0
+i
+q
+" "CPU0,PC=0x1>"
+
+# 18. 2語命令でPCが+2
+run_test "PC inc (2-byte) SBC ACC, d" "
+w 0 0x82
+w 1 0x00
+s pc 0
+s cf 0
+i
+q
+" "CPU0,PC=0x2>"
+
+# --- テストサマリ ---
+echo "===================="
+echo "Test Summary"
+echo "===================="
+echo "TOTAL: $TEST_COUNT, PASS: $PASS_COUNT, FAIL: $FAIL_COUNT"
+echo
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- add ADC and SBC opcodes to ISA
- implement `isa_adc` and `isa_sbc`
- register new instructions in the execution table
- add comprehensive tests for ADC and SBC
- improve ADC/SBC tests for CF=0 and ZF cases

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6854e0d0f6bc833393688d55b1ae614f