### PR TITLE
Add additional shift/rotate tests

### DIFF
--- a/include/inst_shift.h
+++ b/include/inst_shift.h
@@ -1,0 +1,8 @@
+#ifndef INST_SHIFT_H
+#define INST_SHIFT_H
+
+#include "isa.h"
+
+int isa_shift(Cpub *cpub, const Instruction *inst);
+
+#endif /* INST_SHIFT_H */

--- a/include/isa.h
+++ b/include/isa.h
@@ -8,6 +8,7 @@ typedef enum {
     OP_IO  = 0x10,
     OP_CF  = 0x20,
     OP_B   = 0x30,
+    OP_SR  = 0x40,
     OP_LD  = 0x60,
     OP_ST  = 0x70,
     OP_SBC = 0x80,
@@ -35,6 +36,13 @@ typedef enum {
     OP_B_IX_D  = 0x7,
 } OperandMode;
 
+typedef enum {
+    SHIFT_RA = 0,
+    SHIFT_LA = 1,
+    SHIFT_RL = 2,
+    SHIFT_LL = 3,
+} ShiftMode;
+
 typedef struct {
     Uword raw;      /* first byte */
     Opcode opcode;  /* high nibble */
@@ -42,6 +50,8 @@ typedef struct {
     OperandMode mode; /* B field */
     Uword d;        /* B' byte if present */
     Uword imm;      /* decoded operand */
+    ShiftMode sm;   /* shift/rotate mode */
+    Bit is_rot;     /* rotate instruction flag */
 } Instruction;
 
 typedef int (*ExecFunc)(Cpub *, const Instruction *);

--- a/src/cpu_decode.c
+++ b/src/cpu_decode.c
@@ -15,6 +15,10 @@ void decode(Cpub *cpub, Instruction *inst)
         return;
     }
 
+    if (inst->opcode == OP_SR) {
+        return;
+    }
+
     if (needs_operand(inst->mode)) {
         inst->d = mem_read(cpub, cpub->pc++);
     }

--- a/src/cpu_fetch.c
+++ b/src/cpu_fetch.c
@@ -5,10 +5,16 @@ int fetch(Cpub *cpub, Instruction *out)
     out->raw = mem_read(cpub, cpub->pc++);
     out->opcode = (Opcode)(out->raw & 0xF0);
     out->dest = (DestReg)((out->raw >> 3) & 0x1);
-    Uword b = out->raw & 0x07;
-    if (b == 0x03)
-        b = 0x02; /* 010 and 011 are both immediate */
-    out->mode = (OperandMode)b;
+    if (out->opcode == OP_SR) {
+        out->is_rot = (out->raw & 0x04) != 0;
+        out->sm = (ShiftMode)(out->raw & 0x03);
+        out->mode = OP_B_ACC; /* unused */
+    } else {
+        Uword b = out->raw & 0x07;
+        if (b == 0x03)
+            b = 0x02; /* 010 and 011 are both immediate */
+        out->mode = (OperandMode)b;
+    }
     out->d = 0;
     out->imm = 0;
     return 1;

--- a/src/inst_shift.c
+++ b/src/inst_shift.c
@@ -1,0 +1,81 @@
+#include "inst_shift.h"
+
+static Uword read_reg(const Cpub *cpub, DestReg reg)
+{
+    return (reg == DEST_ACC) ? cpub->acc : cpub->ix;
+}
+
+static void write_reg(Cpub *cpub, DestReg reg, Uword val)
+{
+    if (reg == DEST_ACC) {
+        cpub->acc = val;
+    } else {
+        cpub->ix = val;
+    }
+}
+
+int isa_shift(Cpub *cpub, const Instruction *inst)
+{
+    Uword val = read_reg(cpub, inst->dest);
+    Uword result = val;
+    Bit b0 = val & 0x1;
+    Bit b7 = (val >> 7) & 0x1;
+
+    if (inst->is_rot) {
+        switch (inst->sm) {
+        case SHIFT_RA: /* RRA: rotate right through carry */
+            result = (val >> 1) | ((cpub->cf & 1) << 7);
+            cpub->cf = b0;
+            break;
+        case SHIFT_LA: /* RLA: rotate left through carry */
+            result = ((val << 1) & 0xFF) | (cpub->cf & 1);
+            cpub->cf = b7;
+            break;
+        case SHIFT_RL: /* RRL: rotate right */
+            result = (val >> 1) | (b0 << 7);
+            cpub->cf = b0;
+            break;
+        case SHIFT_LL: /* RLL: rotate left */
+            result = ((val << 1) & 0xFF) | b7;
+            cpub->cf = b7;
+            break;
+        }
+        cpub->vf = 0;
+        cpub->nf = (result & 0x80) != 0;
+        cpub->zf = (result == 0);
+    } else {
+        switch (inst->sm) {
+        case SHIFT_RA: /* SRA */
+            result = (val >> 1) | (val & 0x80);
+            cpub->cf = b0;
+            cpub->vf = 0;
+            cpub->nf = (result & 0x80) != 0;
+            cpub->zf = (result == 0);
+            break;
+        case SHIFT_LA: /* SLA */
+            result = (val << 1) & 0xFF;
+            cpub->cf = b7;
+            cpub->vf = (b7 ^ ((result >> 7) & 1)) != 0;
+            cpub->nf = (result & 0x80) != 0;
+            cpub->zf = (result == 0);
+            break;
+        case SHIFT_RL: /* SRL */
+            result = val >> 1;
+            cpub->cf = b0;
+            cpub->vf = 0;
+            cpub->nf = 0;
+            cpub->zf = (result == 0);
+            break;
+        case SHIFT_LL: /* SLL */
+            result = (val << 1) & 0xFF;
+            cpub->cf = b7;
+            cpub->vf = (b7 ^ ((result >> 7) & 1)) != 0;
+            cpub->nf = (result & 0x80) != 0;
+            cpub->zf = (result == 0);
+            break;
+        }
+    }
+
+    write_reg(cpub, inst->dest, result);
+    return RUN_STEP;
+}

--- a/src/isa_table.c
+++ b/src/isa_table.c
@@ -5,6 +5,7 @@
 #include "inst_or.h"
 #include "inst_and.h"
 #include "inst_cmp.h"
+#include "inst_shift.h"
 #include "inst_add.h"
 #include "inst_adc.h"
 #include "inst_sub.h"
@@ -18,6 +19,7 @@ ExecFunc isa_exec_table[256] = {
     [OP_SYS] = isa_hlt,
     [OP_IO]  = isa_io,
     [OP_CF]  = isa_cf,
+    [OP_SR]  = isa_shift,
     [OP_B]   = isa_bnz,
     [OP_LD]  = isa_ld,
     [OP_ST]  = isa_st,

--- a/tests/test_rotate.sh
+++ b/tests/test_rotate.sh
@@ -1,0 +1,193 @@
+#!/bin/sh
+set -e
+SCRIPT_DIR="$(dirname "$0")"
+BIN="$SCRIPT_DIR/../cpu_project_2"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+TEST_COUNT=0
+
+run_test() {
+  TEST_NAME=$1
+  COMMANDS=$2
+  EXPECTED=$3
+
+  TEST_COUNT=$((TEST_COUNT + 1))
+  echo "--- Running test: $TEST_NAME ---"
+
+  output=$("$BIN" <<EOS 2>&1
+${COMMANDS}
+EOS
+)
+
+  if echo "$output" | grep -q "$EXPECTED"; then
+    echo "PASS"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL"
+    echo "====DEBUG INFO====="
+    echo "$output"
+    echo "==================="
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+  echo
+}
+
+# --- Rotate instruction tests ---
+# RRA ACC
+run_test "RRA ACC" "
+w 0 0x44
+s pc 0
+s acc 0x95
+s cf 1
+i
+d
+q
+" "acc=0xca.*cf=1.*vf=0.*nf=1.*zf=0"
+
+# RLA ACC
+run_test "RLA ACC" "
+w 0 0x45
+s pc 0
+s acc 0x12
+s cf 1
+i
+d
+q
+" "acc=0x25.*cf=0.*vf=0.*nf=0.*zf=0"
+
+# RRL ACC
+run_test "RRL ACC" "
+w 0 0x46
+s pc 0
+s acc 0x81
+i
+d
+q
+" "acc=0xc0.*cf=1.*vf=0.*nf=1.*zf=0"
+
+# RLL ACC
+run_test "RLL ACC" "
+w 0 0x47
+s pc 0
+s acc 0x81
+i
+d
+q
+" "acc=0x03.*cf=1.*vf=0.*nf=0.*zf=0"
+
+# RRA ACC cf=0
+run_test "RRA ACC cf=0" "
+w 0 0x44
+s pc 0
+s acc 0x80
+s cf 0
+i
+d
+q
+" "acc=0x40.*cf=0.*vf=0.*nf=0.*zf=0"
+
+# RLA ACC cf=0
+run_test "RLA ACC cf=0" "
+w 0 0x45
+s pc 0
+s acc 0x01
+s cf 0
+i
+d
+q
+" "acc=0x02.*cf=0.*vf=0.*nf=0.*zf=0"
+
+# RRL ACC cfout=0
+run_test "RRL ACC cfout=0" "
+w 0 0x46
+s pc 0
+s acc 0x02
+i
+d
+q
+" "acc=0x01.*cf=0.*vf=0.*nf=0.*zf=0"
+
+# RLL ACC cfout=0
+run_test "RLL ACC cfout=0" "
+w 0 0x47
+s pc 0
+s acc 0x40
+i
+d
+q
+" "acc=0x80.*cf=0.*vf=0.*nf=1.*zf=0"
+
+# RRA ACC zero result
+run_test "RRA ACC ZF" "
+w 0 0x44
+s pc 0
+s acc 0x00
+s cf 0
+i
+d
+q
+" "acc=0x00.*cf=0.*vf=0.*nf=0.*zf=1"
+
+# RRA IX
+run_test "RRA IX" "
+w 0 0x4c
+s pc 0
+s ix 0x95
+s cf 1
+i
+d
+q
+" "ix=0xca.*cf=1.*vf=0.*nf=1.*zf=0"
+
+# RLA IX
+run_test "RLA IX" "
+w 0 0x4d
+s pc 0
+s ix 0x12
+s cf 1
+i
+d
+q
+" "ix=0x25.*cf=0.*vf=0.*nf=0.*zf=0"
+
+# RRL IX
+run_test "RRL IX" "
+w 0 0x4e
+s pc 0
+s ix 0x81
+i
+d
+q
+" "ix=0xc0.*cf=1.*vf=0.*nf=1.*zf=0"
+
+# RLL IX
+run_test "RLL IX" "
+w 0 0x4f
+s pc 0
+s ix 0x81
+i
+d
+q
+" "ix=0x03.*cf=1.*vf=0.*nf=0.*zf=0"
+
+# PC increment check
+run_test "PC inc RRA" "
+w 0 0x44
+s pc 0
+i
+q
+" "CPU0,PC=0x1>"
+
+# --- Test summary ---
+echo "===================="
+echo "Test Summary"
+echo "===================="
+echo "TOTAL: $TEST_COUNT, PASS: $PASS_COUNT, FAIL: $FAIL_COUNT"
+echo
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  exit 1
+fi
+
+exit 0

--- a/tests/test_shift.sh
+++ b/tests/test_shift.sh
@@ -1,0 +1,156 @@
+#!/bin/sh
+set -e
+SCRIPT_DIR="$(dirname "$0")"
+BIN="$SCRIPT_DIR/../cpu_project_2"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+TEST_COUNT=0
+
+run_test() {
+  TEST_NAME=$1
+  COMMANDS=$2
+  EXPECTED=$3
+
+  TEST_COUNT=$((TEST_COUNT + 1))
+  echo "--- Running test: $TEST_NAME ---"
+
+  output=$("$BIN" <<EOS 2>&1
+${COMMANDS}
+EOS
+)
+
+  if echo "$output" | grep -q "$EXPECTED"; then
+    echo "PASS"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL"
+    echo "====DEBUG INFO====="
+    echo "$output"
+    echo "==================="
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+  echo
+}
+
+# --- Shift instruction tests ---
+# SRA ACC
+run_test "SRA ACC" "
+w 0 0x40
+s pc 0
+s acc 0x95
+i
+d
+q
+" "acc=0xca.*cf=1.*vf=0.*nf=1.*zf=0"
+
+# SLA ACC
+run_test "SLA ACC" "
+w 0 0x41
+s pc 0
+s acc 0x40
+i
+d
+q
+" "acc=0x80.*cf=0.*vf=1.*nf=1.*zf=0"
+
+# SRL ACC
+run_test "SRL ACC" "
+w 0 0x42
+s pc 0
+s acc 0x01
+i
+d
+q
+" "acc=0x00.*cf=1.*vf=0.*nf=0.*zf=1"
+
+# SLL ACC
+run_test "SLL ACC" "
+w 0 0x43
+s pc 0
+s acc 0x80
+i
+d
+q
+" "acc=0x00.*cf=1.*vf=1.*nf=0.*zf=1"
+
+# SRA ACC pos
+run_test "SRA ACC pos" "
+w 0 0x40
+s pc 0
+s acc 0x40
+i
+d
+q
+" "acc=0x20.*cf=0.*vf=0.*nf=0.*zf=0"
+
+# SLL ACC VF0
+run_test "SLL ACC VF0" "
+w 0 0x43
+s pc 0
+s acc 0x20
+i
+d
+q
+" "acc=0x40.*cf=0.*vf=0.*nf=0.*zf=0"
+
+# SRA IX
+run_test "SRA IX" "
+w 0 0x48
+s pc 0
+s ix 0x95
+i
+d
+q
+" "ix=0xca.*cf=1.*vf=0.*nf=1.*zf=0"
+
+# SLA IX
+run_test "SLA IX" "
+w 0 0x49
+s pc 0
+s ix 0x40
+i
+d
+q
+" "ix=0x80.*cf=0.*vf=1.*nf=1.*zf=0"
+
+# SRL IX
+run_test "SRL IX" "
+w 0 0x4a
+s pc 0
+s ix 0x01
+i
+d
+q
+" "ix=0x00.*cf=1.*vf=0.*nf=0.*zf=1"
+
+# SLL IX
+run_test "SLL IX" "
+w 0 0x4b
+s pc 0
+s ix 0x80
+i
+d
+q
+" "ix=0x00.*cf=1.*vf=1.*nf=0.*zf=1"
+
+# PC increment check
+run_test "PC inc SRA" "
+w 0 0x40
+s pc 0
+i
+q
+" "CPU0,PC=0x1>"
+
+# --- Test summary ---
+echo "===================="
+echo "Test Summary"
+echo "===================="
+echo "TOTAL: $TEST_COUNT, PASS: $PASS_COUNT, FAIL: $FAIL_COUNT"
+echo
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- cover shift and rotate instructions on IX register
- add zero flag and carry variations for rotate tests
- verify SRA positive and SLL cases where VF remains clear

## Testing
- `make test`
- `sh tests/test_shift.sh`
- `sh tests/test_rotate.sh`


------
https://chatgpt.com/codex/tasks/task_e_6854e8b6a818833399cf7668a4ab0173