### PR TITLE
Add JAL and JR instruction support

### DIFF
--- a/src/cpu_decode.c
+++ b/src/cpu_decode.c
@@ -19,6 +19,17 @@ void decode(Cpub *cpub, Instruction *inst)
         return;
     }
 
+    if (inst->opcode == OP_SYS) {
+        Uword sub = inst->raw & 0x0F;
+        if (sub == 0x0A) { /* JAL */
+            inst->d = mem_read(cpub, cpub->pc++);
+            inst->imm = inst->d;
+            return;
+        } else if (sub == 0x0B) { /* JR */
+            return;
+        }
+    }
+
     if (needs_operand(inst->mode)) {
         inst->d = mem_read(cpub, cpub->pc++);
     }

--- a/src/inst_hlt.c
+++ b/src/inst_hlt.c
@@ -2,7 +2,7 @@
 
 int isa_hlt(Cpub *cpub, const Instruction *inst)
 {
-    (void)cpub;
+    Uword sub = inst->raw & 0x0F;
 
     /* NOP opcodes are 0x00 through 0x03 */
     if ((inst->raw & 0xFC) == 0x00) {
@@ -12,6 +12,17 @@ int isa_hlt(Cpub *cpub, const Instruction *inst)
     /* HLT opcodes are 0x0C through 0x0F */
     if (inst->raw >= 0x0c && inst->raw <= 0x0f) {
         return RUN_HALT;
+    }
+
+    if (sub == 0x0A) { /* JAL */
+        cpub->acc = cpub->pc;
+        cpub->pc = inst->d;
+        return RUN_STEP;
+    }
+
+    if (sub == 0x0B) { /* JR */
+        cpub->pc = cpub->acc;
+        return RUN_STEP;
     }
 
     /* Other system instructions are treated as NOP for now */

--- a/tests/test_jal_jr.sh
+++ b/tests/test_jal_jr.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+set -e
+SCRIPT_DIR="$(dirname "$0")"
+BIN="$SCRIPT_DIR/../cpu_project_2"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+TEST_COUNT=0
+
+run_test() {
+  TEST_NAME=$1
+  COMMANDS=$2
+  EXPECTED=$3
+
+  TEST_COUNT=$((TEST_COUNT + 1))
+  echo "--- Running test: $TEST_NAME ---"
+
+  output=$("$BIN" <<EOS 2>&1
+${COMMANDS}
+EOS
+)
+
+  if echo "$output" | grep -q "$EXPECTED"; then
+    echo "PASS"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL"
+    echo "====DEBUG INFO====="
+    echo "$output"
+    echo "==================="
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+  echo
+}
+
+# JAL should store return address in ACC and jump to target without side effects
+run_test "JAL basic" "
+w 0 0x0a
+w 1 0x20
+s pc 0
+s ix 0xaa
+s cf 1
+s vf 1
+s nf 1
+s zf 1
+i
+d
+q
+" "CPU0,PC=0x20>.*acc=0x02.*ix=0xaa.*cf=1.*vf=1.*nf=1.*zf=1"
+
+# JR should jump to address in ACC without altering registers or flags
+run_test "JR basic" "
+w 0 0x0b
+s pc 0
+s acc 0x30
+s ix 0xbb
+s cf 1
+s vf 1
+s nf 1
+s zf 1
+i
+d
+q
+" "CPU0,PC=0x30>.*acc=0x30.*ix=0xbb.*cf=1.*vf=1.*nf=1.*zf=1"
+
+# --- Test summary ---
+echo "===================="
+echo "Test Summary"
+echo "===================="
+echo "TOTAL: $TEST_COUNT, PASS: $PASS_COUNT, FAIL: $FAIL_COUNT"
+echo
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- decode JAL/JR opcodes properly
- implement JAL/JR behavior in system instruction handler
- add tests for JAL and JR
- expand JAL/JR tests with side-effect checks

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6854ef9ce63c8333a9b4ed964e34d2e2