### PR TITLE
Add fizz_buzz run option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,15 @@ TOYCC_DIR=toycc
 CPU_BIN=$(CPU_DIR)/cpu_project_2
 TOYCC_BIN=$(TOYCC_DIR)/toycc_compiler
 
-EXAMPLE_SRC=examples/sample.tc
-EXAMPLE_BIN=examples/sample.txt
+EXAMPLE=sample
+ifneq ($(filter fizz_buzz,$(MAKECMDGOALS)),)
+EXAMPLE=fizz_buzz
+endif
 
-.PHONY: all clean run
+EXAMPLE_SRC=examples/$(EXAMPLE).tc
+EXAMPLE_BIN=examples/$(EXAMPLE).txt
+
+.PHONY: all clean run fizz_buzz
 
 all: $(CPU_BIN) $(TOYCC_BIN)
 
@@ -16,13 +21,15 @@ $(CPU_BIN):
 $(TOYCC_BIN):
 	$(MAKE) -C $(TOYCC_DIR)
 
-$(EXAMPLE_BIN): $(EXAMPLE_SRC) $(TOYCC_BIN)
-	$(TOYCC_BIN) $(EXAMPLE_SRC) $(EXAMPLE_BIN)
+examples/%.txt: examples/%.tc $(TOYCC_BIN)
+	$(TOYCC_BIN) $< $@
 
 run: all $(EXAMPLE_BIN)
-	echo "r $(EXAMPLE_BIN)\nc\nm 0x100\nm 0x101\nq" | $(CPU_BIN)
+	echo "r $(EXAMPLE_BIN)\nc\nd\nq" | $(CPU_BIN)
+
+fizz_buzz:
 
 clean:
 	$(MAKE) -C $(CPU_DIR) clean
 	$(MAKE) -C $(TOYCC_DIR) clean
-	rm -f $(EXAMPLE_BIN)
+	rm -f examples/*.txt

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ variable declarations and assignments. It also offers rudimentary arrays and
 basic I/O using `in` and `out` statements. Arrays are backed by consecutive
 memory addresses and accessed via `name[index]`. Example programs demonstrating
 these features are provided in the `examples` directory (`bubble_sort.tc`,
-`quicksort.tc` and `fizzbuzz.tc`).
+`quicksort.tc` and `fizz_buzz.tc`).
 
 ## Run the Example
 
@@ -41,6 +41,13 @@ contiguous regions beginning at their base address.
 
 ```
 $ make run
+```
+
+To run a different example such as `fizz_buzz.tc`, append the file stem after
+`run`:
+
+```
+$ make run fizz_buzz
 ```
 
 ## Clean


### PR DESCRIPTION
## Summary
- allow selecting the fizz_buzz example via `make run fizz_buzz`
- document how to run alternate examples
- clean up example artifacts when running `make clean`

## Testing
- `make -C cpu test`
- `make run fizz_buzz`
- `make run`

------
https://chatgpt.com/codex/tasks/task_e_6855414052b883339242e2608d64be51